### PR TITLE
[cpp-httplib]Add to oss-fuzz

### DIFF
--- a/projects/cpp-httplib/Dockerfile
+++ b/projects/cpp-httplib/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+#Install brotli
+RUN apt-get install -y libbrotli-dev
+
+#Install zlib
+RUN apt-get update && apt-get install -y zlib1g-dev
+
+# Install openssl 1.1.1
+RUN curl -o openssl-1.1.1f.tar.gz https://www.openssl.org/source/openssl-1.1.1f.tar.gz && \
+    tar xzvf  openssl-1.1.1f.tar.gz
+RUN  cd openssl-1.1.1f && ./config && make && make install_sw
+
+# Clone remote repo
+RUN  date > /tmp/time.txt
+RUN git clone -b fuzz-targets https://github.com/omjego/cpp-httplib.git cpp-httplib
+WORKDIR cpp-httplib
+COPY build.sh $SRC/

--- a/projects/cpp-httplib/Dockerfile
+++ b/projects/cpp-httplib/Dockerfile
@@ -28,8 +28,8 @@ RUN curl -o openssl-1.1.1f.tar.gz https://www.openssl.org/source/openssl-1.1.1f.
     tar xzvf  openssl-1.1.1f.tar.gz
 RUN  cd openssl-1.1.1f && ./config && make && make install_sw
 
-# Clone remote repo
-RUN  date > /tmp/time.txt
-RUN git clone -b fuzz-targets https://github.com/omjego/cpp-httplib.git cpp-httplib
+# TODO use remote repo instead of forked one.
+RUN git clone -b http-oss-fuzz https://github.com/omjego/cpp-httplib.git cpp-httplib
+
 WORKDIR cpp-httplib
 COPY build.sh $SRC/

--- a/projects/cpp-httplib/Dockerfile
+++ b/projects/cpp-httplib/Dockerfile
@@ -17,16 +17,16 @@
 FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 
-#Install brotli
+# Install brotli.
 RUN apt-get install -y libbrotli-dev
 
-#Install zlib
+# Install zlib.
 RUN apt-get update && apt-get install -y zlib1g-dev
 
 # Install openssl 1.1.1
 RUN curl -o openssl-1.1.1f.tar.gz https://www.openssl.org/source/openssl-1.1.1f.tar.gz && \
     tar xzvf  openssl-1.1.1f.tar.gz
-RUN  cd openssl-1.1.1f && ./config && make && make install_sw
+RUN cd openssl-1.1.1f && ./config && make && make install_sw
 
 # TODO use remote repo instead of forked one.
 RUN git clone -b http-oss-fuzz https://github.com/omjego/cpp-httplib.git cpp-httplib

--- a/projects/cpp-httplib/Dockerfile
+++ b/projects/cpp-httplib/Dockerfile
@@ -28,8 +28,7 @@ RUN curl -o openssl-1.1.1f.tar.gz https://www.openssl.org/source/openssl-1.1.1f.
     tar xzvf  openssl-1.1.1f.tar.gz
 RUN cd openssl-1.1.1f && ./config && make && make install_sw
 
-# TODO use remote repo instead of forked one.
-RUN git clone -b http-oss-fuzz https://github.com/omjego/cpp-httplib.git cpp-httplib
+RUN git clone --depth 1 https://github.com/yhirose/cpp-httplib.git cpp-httplib
 
 WORKDIR cpp-httplib
 COPY build.sh $SRC/

--- a/projects/cpp-httplib/build.sh
+++ b/projects/cpp-httplib/build.sh
@@ -15,10 +15,10 @@
 #
 ################################################################################
 
-# build fuzz targets specified  in test/Makefile
+# Build fuzz targets specified  in test/Makefile.
 cd test/fuzzing && make -j$(nproc) server_fuzzer
 
-# Copy the fuzzer executables, zip-ed corpora, option and dictionary files to $OUT
+# Copy the fuzzer executables, zip-ed corpora, option and dictionary files to $OUT.
 find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'          # Copy fuzz-target.
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'     # Copy dictionaries.
-find . -name '*_fuzzer_seed_corpus.zip' -exec cp -v '{}' $OUT ';' # Copy seed corpora
+find . -name '*_fuzzer_seed_corpus.zip' -exec cp -v '{}' $OUT ';' # Copy seed corpora.

--- a/projects/cpp-httplib/build.sh
+++ b/projects/cpp-httplib/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build fuzz targets specified  in test/Makefile
+cd test && make -j$(nproc) gen-fuzzers
+
+# Copy the fuzzer executables, zip-ed corpora, option and dictionary files to $OUT
+find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'          # Copy fuzz-target.
+find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'     # Copy dictionaries.

--- a/projects/cpp-httplib/build.sh
+++ b/projects/cpp-httplib/build.sh
@@ -16,8 +16,9 @@
 ################################################################################
 
 # build fuzz targets specified  in test/Makefile
-cd test && make -j$(nproc) gen-fuzzers
+cd test && make -j$(nproc) server_fuzzer
 
 # Copy the fuzzer executables, zip-ed corpora, option and dictionary files to $OUT
 find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'          # Copy fuzz-target.
 find . -name '*_fuzzer.dict' -exec cp -v '{}' $OUT ';'     # Copy dictionaries.
+find . -name '*_fuzzer_seed_corpus.zip' -exec cp -v '{}' $OUT ';' # Copy seed corpora

--- a/projects/cpp-httplib/build.sh
+++ b/projects/cpp-httplib/build.sh
@@ -16,7 +16,7 @@
 ################################################################################
 
 # build fuzz targets specified  in test/Makefile
-cd test && make -j$(nproc) server_fuzzer
+cd test/fuzzing && make -j$(nproc) server_fuzzer
 
 # Copy the fuzzer executables, zip-ed corpora, option and dictionary files to $OUT
 find . -name '*_fuzzer' -exec cp -v '{}' $OUT ';'          # Copy fuzz-target.

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -10,4 +10,3 @@ sanitizers:
   - undefined
 architectures:
   - x86_64
-  - i386

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -7,5 +7,3 @@ sanitizers:
   - address
   - dataflow
   - undefined
-architectures:
-  - x86_64

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -1,0 +1,13 @@
+homepage: "https://github.com/yhirose/cpp-httplib"
+language: c++
+primary_contact: "omkarjadhav@google.com"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+  - dataflow
+  - memory
+  - undefined
+architectures:
+  - x86_64
+  - i386

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -3,8 +3,6 @@ language: c++
 primary_contact: "yuji.hirose.bug@gmail.com"
 auto_ccs :
   - "omkarjadhav@google.com"
-fuzzing_engines:
-  - libfuzzer
 sanitizers:
   - address
   - dataflow

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -6,7 +6,6 @@ auto_ccs :
 sanitizers:
   - address
   - dataflow
-  - memory
   - undefined
 architectures:
   - x86_64

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -1,6 +1,8 @@
 homepage: "https://github.com/yhirose/cpp-httplib"
 language: c++
-primary_contact: "omkarjadhav@google.com"
+primary_contact: "yuji.hirose.bug@gmail.com"
+auto_ccs :
+  - "omkarjadhav@google.com"
 fuzzing_engines:
   - libfuzzer
 sanitizers:

--- a/projects/cpp-httplib/project.yaml
+++ b/projects/cpp-httplib/project.yaml
@@ -2,7 +2,7 @@ homepage: "https://github.com/yhirose/cpp-httplib"
 language: c++
 primary_contact: "yuji.hirose.bug@gmail.com"
 auto_ccs :
-  - "omkarjadhav@google.com"
+  - "cpp-httplib-oss-fuzz@googlegroups.com"
 sanitizers:
   - address
   - dataflow


### PR DESCRIPTION
- Depends on https://github.com/omjego/cpp-httplib/pull/2. 
- Will change repo link in Dockerfile after above gets merged.

Testing locally: 
``` 
cd oss-fuzz
export PROJECT_NAME=cpp-httplib  
python infra/helper.py build_fuzzers --sanitizer address $PROJECT_NAME
python infra/helper.py run_fuzzer $PROJECT_NAME server_fuzzer
```